### PR TITLE
hotfix(makefile): fixing makefile - up, down  and stop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,8 @@ up:
 	$(call title1,"STARTING ALL SERVICES")
 	$(call check_command,docker,"Install Docker from https://docs.docker.com/get-docker/")
 	$(call check_env_files)
-	@echo "$(BLUE)Setting up and starting Midaz services...$(NC)"
-	@cd $(MIDAZ_DIR) && make all-services COMMAND="up"
-	@echo "$(BLUE)Setting up and starting Midaz Console...$(NC)"
+	@cd $(MIDAZ_DIR) && make up
+	@echo "$(BLUE)Starting Midaz Console...$(NC)"
 	@cd $(MIDAZ_CONSOLE_DIR) && npm update && npm run docker-up
 	@echo "$(GREEN)$(BOLD)[ok]$(NC) All services started successfully$(GREEN) ✔️$(NC)"
 
@@ -79,7 +78,7 @@ stop:
 	$(call title1,"STOPPING ALL SERVICES")
 	$(call check_command,docker,"Install Docker from https://docs.docker.com/get-docker/")
 	@echo "$(BLUE)Stopping Midaz services...$(NC)"
-	@cd $(MIDAZ_DIR) && make all-services COMMAND="stop"
+	@cd $(MIDAZ_DIR) && make stop
 	@echo "$(BLUE)Stopping Midaz Console...$(NC)"
 	@cd $(MIDAZ_CONSOLE_DIR) && $(DOCKER_CMD) stop
 	@echo "$(GREEN)$(BOLD)[ok]$(NC) All services stopped successfully$(GREEN) ✔️$(NC)"
@@ -90,7 +89,7 @@ down:
 	$(call title1,"DOWNING ALL SERVICES")
 	$(call check_command,docker,"Install Docker from https://docs.docker.com/get-docker/")
 	@echo "$(BLUE)Downing Midaz services...$(NC)"
-	@cd $(MIDAZ_DIR) && make all-services COMMAND="down"
+	@cd $(MIDAZ_DIR) && make down
 	@echo "$(BLUE)Downing Midaz Console...$(NC)"
 	@cd $(MIDAZ_CONSOLE_DIR) && $(DOCKER_CMD) down
 	@echo "$(GREEN)$(BOLD)[ok]$(NC) All services downed successfully$(GREEN) ✔️$(NC)"
@@ -165,6 +164,8 @@ midaz-help:
 	@echo "  stop                        - Stop all Midaz containers"
 	@echo "  restart                     - Restart all Midaz containers"
 	@echo "  rebuild-up                  - Rebuild and restart all Midaz services"
+	@echo "  clean-docker                - Clean all Docker resources (containers, networks, volumes)"
+	@echo "  destroy                     - Alias for clean-docker (maintained for compatibility)"
 	@echo ""
 
 .PHONY: midaz-console-help


### PR DESCRIPTION
This pull request includes several changes to the `Makefile` to simplify and clarify the commands for managing the Midaz services. The most important changes involve modifying the `up`, `stop`, and `down` commands to use more straightforward make targets, and adding new help descriptions for Docker resource cleanup.

Simplification of service management commands:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L70-R71): Modified the `up` command to use `make up` instead of `make all-services COMMAND="up"` for starting Midaz services.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L82-R81): Modified the `stop` command to use `make stop` instead of `make all-services COMMAND="stop"` for stopping Midaz services.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L93-R92): Modified the `down` command to use `make down` instead of `make all-services COMMAND="down"` for downing Midaz services.

Enhancements to help descriptions:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R167-R168): Added help descriptions for `clean-docker` and `destroy` commands to clean all Docker resources and maintain compatibility.